### PR TITLE
🔒 [security fix] Fix Path Traversal in Document Provider

### DIFF
--- a/app/src/test/kotlin/io/github/asutorufa/yuhaiin/docuemntprovider/PathTraversalTest.kt
+++ b/app/src/test/kotlin/io/github/asutorufa/yuhaiin/docuemntprovider/PathTraversalTest.kt
@@ -1,0 +1,43 @@
+package io.github.asutorufa.yuhaiin.docuemntprovider
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class PathTraversalTest {
+
+    @Test
+    fun testIsChild() {
+        val provider = YuhaiinDocumentProvider()
+        val tempDir = Files.createTempDirectory("yuhaiin_test").toFile().canonicalFile
+        val subDir = File(tempDir, "subdir")
+        subDir.mkdir()
+        val fileInSubDir = File(subDir, "file.txt")
+        fileInSubDir.createNewFile()
+
+        val otherDir = Files.createTempDirectory("yuhaiin_other").toFile().canonicalFile
+        val otherFile = File(otherDir, "other.txt")
+        otherFile.createNewFile()
+
+        // Construct a path that looks like it's inside tempDir but isn't after canonicalization
+        val traversalFile = File(tempDir, "../" + otherDir.name + "/other.txt")
+
+        assertTrue("Should be child of itself", provider.isChild(tempDir, tempDir))
+        assertTrue("Should be child of tempDir", provider.isChild(tempDir, subDir))
+        assertTrue("Should be child of tempDir", provider.isChild(tempDir, fileInSubDir))
+
+        assertFalse("Should not be child of otherDir", provider.isChild(tempDir, otherDir))
+        assertFalse("Should not be child of otherDir", provider.isChild(tempDir, otherFile))
+        assertFalse("Traversal should be blocked: ${traversalFile.path}", provider.isChild(tempDir, traversalFile))
+
+        val partialMatchDir = File(tempDir.parentFile, tempDir.name + "_extra")
+        partialMatchDir.mkdir()
+        assertFalse("Partial name match should be blocked: ${partialMatchDir.path}", provider.isChild(tempDir, partialMatchDir))
+
+        tempDir.deleteRecursively()
+        otherDir.deleteRecursively()
+        partialMatchDir.deleteRecursively()
+    }
+}


### PR DESCRIPTION
This PR fixes a path traversal vulnerability in `YuhaiinDocumentProvider`.

🎯 **What:** The vulnerability fixed is a path traversal in the Document Provider.
⚠️ **Risk:** Without this fix, an attacker or a malicious app could potentially access or delete sensitive files outside of the intended directory by providing a manipulated `docId` containing `..` or absolute paths.
🛡️ **Solution:** The fix introduces a secure `isChild` helper that uses `canonicalPath` to resolve all path components and ensures that the requested file is strictly within the allowed `baseDir`. It also correctly handles directory boundary checks to prevent partial name match attacks.

A new unit test `PathTraversalTest.kt` was added to verify the fix.

---
*PR created automatically by Jules for task [16491326315817938800](https://jules.google.com/task/16491326315817938800) started by @Asutorufa*