### PR TITLE
⚡ Optimize VPN Service Startup Performance

### DIFF
--- a/app/src/main/kotlin/io/github/asutorufa/yuhaiin/service/YuhaiinVpnService.kt
+++ b/app/src/main/kotlin/io/github/asutorufa/yuhaiin/service/YuhaiinVpnService.kt
@@ -212,10 +212,13 @@ class YuhaiinVpnService : VpnService() {
                     start(tunAddress)
                 }
 
-                state = State.CONNECTED
+                if (state == State.CONNECTING) {
+                    state = State.CONNECTED
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Ignore cancellation
             } catch (e: Exception) {
-                e.printStackTrace()
-                state = State.DISCONNECTED
+                Log.e(tag, "Failed to start VPN", e)
                 callbacks.sendMsg(e.toString())
                 onRevoke()
             }

--- a/app/src/main/kotlin/io/github/asutorufa/yuhaiin/service/YuhaiinVpnService.kt
+++ b/app/src/main/kotlin/io/github/asutorufa/yuhaiin/service/YuhaiinVpnService.kt
@@ -25,6 +25,12 @@ import io.github.asutorufa.yuhaiin.IYuhaiinVpnCallback
 import io.github.asutorufa.yuhaiin.MainActivity
 import io.github.asutorufa.yuhaiin.MainApplication
 import io.github.asutorufa.yuhaiin.R
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import yuhaiin.App
 import yuhaiin.Closer
@@ -80,14 +86,17 @@ class YuhaiinVpnService : VpnService() {
         finishBroadcast()
     }
 
+    private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val mBinder = VpnBinder()
     private val tag = this.javaClass.simpleName
+    @Volatile
     private var state = State.DISCONNECTED
         set(value) {
             field = value
             callbacks.broadcast(value)
         }
 
+    @Volatile
     private var mInterface: ParcelFileDescriptor? = null
     private val notification by lazy { application.getSystemService<NotificationManager>()!! }
     private val app = App()
@@ -155,8 +164,13 @@ class YuhaiinVpnService : VpnService() {
     override fun onBind(intent: Intent?) =
         if (intent?.action == SERVICE_INTERFACE) super.onBind(intent) else mBinder
 
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
+    }
+
     private fun stop() {
-        if (state != State.CONNECTED) return
+        if (state != State.CONNECTED && state != State.CONNECTING) return
         state = State.DISCONNECTING
 
         try {
@@ -188,19 +202,23 @@ class YuhaiinVpnService : VpnService() {
         }
 
         state = State.CONNECTING
+        startNotification()
 
-        try {
-            val tunAddress = Yuhaiin.getTunAddress()
-            configure(tunAddress)
-            startNotification()
-            start(tunAddress)
+        serviceScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    val tunAddress = Yuhaiin.getTunAddress()
+                    configure(tunAddress)
+                    start(tunAddress)
+                }
 
-            state = State.CONNECTED
-        } catch (e: Exception) {
-            e.printStackTrace()
-            state = State.DISCONNECTED
-            callbacks.sendMsg(e.toString())
-            onRevoke()
+                state = State.CONNECTED
+            } catch (e: Exception) {
+                e.printStackTrace()
+                state = State.DISCONNECTED
+                callbacks.sendMsg(e.toString())
+                onRevoke()
+            }
         }
 
         return START_STICKY


### PR DESCRIPTION
💡 **What:** The optimization implemented
This change moves blocking I/O and JNI calls in `YuhaiinVpnService.onStartCommand` to a background thread using Kotlin Coroutines. It also ensures that `startForeground` is called immediately on the main thread to comply with Android's foreground service requirements.

🎯 **Why:** The performance problem it solves
Previously, the VPN service performed several blocking I/O operations (like reading from `Store`) and JNI calls on the main thread during `onStartCommand`. This could lead to Application Not Responding (ANR) errors and crashes, especially on Android 8+ where failing to call `startForeground` within a few seconds of starting the service results in a crash.

📊 **Measured Improvement:**
While it was impractical to measure the exact millisecond improvement in this environment due to build and network constraints, moving blocking I/O off the main thread is a standard Android performance optimization that prevents main-thread stalls and ANRs. The `onStartCommand` now returns almost immediately, allowing the system to proceed while the VPN initializes in the background. Additionally, calling `startNotification` earlier makes the service more robust against "Service.startForeground() not called" errors.

---
*PR created automatically by Jules for task [3314752751189640977](https://jules.google.com/task/3314752751189640977) started by @Asutorufa*