### PR TITLE
🔒 [security fix] Fix Path Traversal in Document Provider (Updated)

### DIFF
--- a/app/src/test/kotlin/io/github/asutorufa/yuhaiin/docuemntprovider/PathTraversalTest.kt
+++ b/app/src/test/kotlin/io/github/asutorufa/yuhaiin/docuemntprovider/PathTraversalTest.kt
@@ -1,0 +1,45 @@
+package io.github.asutorufa.yuhaiin.docuemntprovider
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class PathTraversalTest {
+
+    @Test
+    fun testIsChild() {
+        val provider = YuhaiinDocumentProvider()
+        val tempDir = Files.createTempDirectory("yuhaiin_test").toFile().canonicalFile
+        val otherDir = Files.createTempDirectory("yuhaiin_other").toFile().canonicalFile
+        val partialMatchDir = File(tempDir.parentFile, tempDir.name + "_extra")
+        try {
+            val subDir = File(tempDir, "subdir")
+            subDir.mkdir()
+            val fileInSubDir = File(subDir, "file.txt")
+            fileInSubDir.createNewFile()
+
+            val otherFile = File(otherDir, "other.txt")
+            otherFile.createNewFile()
+
+            // Construct a path that looks like it's inside tempDir but isn't after canonicalization
+            val traversalFile = File(tempDir, "../" + otherDir.name + "/other.txt")
+
+            assertTrue("Should be child of itself", provider.isChild(tempDir, tempDir))
+            assertTrue("Should be child of tempDir", provider.isChild(tempDir, subDir))
+            assertTrue("Should be child of tempDir", provider.isChild(tempDir, fileInSubDir))
+
+            assertFalse("Should not be child of otherDir", provider.isChild(tempDir, otherDir))
+            assertFalse("Should not be child of otherDir", provider.isChild(tempDir, otherFile))
+            assertFalse("Traversal should be blocked: ${traversalFile.path}", provider.isChild(tempDir, traversalFile))
+
+            partialMatchDir.mkdir()
+            assertFalse("Partial name match should be blocked: ${partialMatchDir.path}", provider.isChild(tempDir, partialMatchDir))
+        } finally {
+            tempDir.deleteRecursively()
+            otherDir.deleteRecursively()
+            partialMatchDir.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
This PR resubmits the path traversal fix with an improved unit test that ensures proper cleanup of temporary directories.

🎯 **What:** The vulnerability fixed is a path traversal in the Document Provider.
⚠️ **Risk:** Potential unauthorized access or deletion of files outside the designated directory.
🛡️ **Solution:** Implemented secure path validation using canonical paths and trailing separator checks.

The unit test `PathTraversalTest.kt` has been updated to use a `try...finally` block for guaranteed cleanup.

---
*PR created automatically by Jules for task [16491326315817938800](https://jules.google.com/task/16491326315817938800) started by @Asutorufa*