### PR TITLE
🔒 Enforce HTTPS by disabling cleartext traffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_v2_round"
         android:theme="@style/Theme.Material3.DayNight.NoActionBar"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="false"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:enableOnBackInvokedCallback="true"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
🎯 **What:** Disabling global cleartext traffic support in the application.
⚠️ **Risk:** Allowing cleartext traffic exposes users to man-in-the-middle (MITM) attacks, potentially leading to data interception or injection.
🛡️ **Solution:** Set `android:usesCleartextTraffic="false"` in the manifest and added a `network_security_config.xml` to strictly limit cleartext traffic to `127.0.0.1` for the local dashboard WebView.

---
*PR created automatically by Jules for task [13859112245081247526](https://jules.google.com/task/13859112245081247526) started by @Asutorufa*