### PR TITLE
🧹 remove unused parseLog function

### DIFF
--- a/app/src/main/kotlin/io/github/asutorufa/yuhaiin/compose/Logcat.kt
+++ b/app/src/main/kotlin/io/github/asutorufa/yuhaiin/compose/Logcat.kt
@@ -453,58 +453,6 @@ fun parseLogv2(line: String): LogEntry {
     return log
 }
 
-fun parseLog(line: String): LogEntry {
-    var i = 0
-    val n = line.length
-
-    fun skipSpaces() {
-        while (i < n && line[i] == ' ') i++
-    }
-
-    fun readWord(): String {
-        val start = i
-        while (i < n && line[i] != ' ') i++
-        return line.substring(start, i)
-    }
-
-    skipSpaces()
-    val date = readWord()
-    skipSpaces()
-    val timeStr = readWord()
-    skipSpaces()
-    val pidStr = readWord()
-    skipSpaces()
-    val tidStr = readWord()
-    skipSpaces()
-    val levelStr = readWord()
-    skipSpaces()
-    val tagStart = i
-    while (i < n && line[i] != ':') i++
-    val tag = if (i < n) line.substring(tagStart, i) else ""
-    i++ // skip ':'
-    val content = if (i < n) line.substring(i).trimStart() else ""
-
-    val level = when (levelStr) {
-        "V", "D" -> LogLevel.DEBUG
-        "I" -> LogLevel.INFO
-        "W" -> LogLevel.WARN
-        "E", "F" -> LogLevel.ERROR
-        else -> LogLevel.INFO
-    }
-
-    if (content.isEmpty())
-        return LogEntry(time = Date().toString(), content = line)
-
-    return LogEntry(
-        level = level,
-        time = "$date $timeStr",
-        content = content,
-        tag = tag,
-        pid = pidStr.toIntOrNull(),
-        tid = tidStr.toIntOrNull()
-    )
-}
-
 @Composable
 @Preview
 fun LogItem(


### PR DESCRIPTION
🎯 **What:** Removed the unused `parseLog` function and its internal helpers (`skipSpaces`, `readWord`) from `Logcat.kt`.
💡 **Why:** `parseLog` was redundant dead code that had been superseded by `parseLogv2`. Removing it improves code readability and maintainability.
✅ **Verification:** Verified that `parseLog` is no longer referenced in the codebase using `grep`. Confirmed that `parseLogv2` is the only active log parsing function and that it remains intact.
✨ **Result:** Reduced codebase complexity and removed dead code.

---
*PR created automatically by Jules for task [11139743742075216607](https://jules.google.com/task/11139743742075216607) started by @Asutorufa*